### PR TITLE
Add Hello World field extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "BC Sandbox",
+            "type": "al",
+            "request": "launch",
+            "server": "https://businesscentral.dynamics.com",
+            "serverInstance": "Sandbox",
+            "authentication": "UserPassword",
+            "startupObjectType": "Page",
+            "startupObjectId": 21
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "al.languageVersion": "11.0"
+}

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "id": "e8c45ae7-1234-1234-1234-123456789abc",
+  "name": "HelloWorldExtension",
+  "publisher": "DummyPublisher",
+  "version": "1.0.0.0",
+  "platform": "11.0.0.0",
+  "application": "11.0.0.0",
+  "runtime": "11.0",
+  "target": "Cloud",
+  "idRanges": [
+    {
+      "from": 50100,
+      "to": 50149
+    }
+  ]
+}

--- a/src/HelloWorldField.al
+++ b/src/HelloWorldField.al
@@ -1,0 +1,22 @@
+pageextension 50100 CustomerCardHelloWorld extends "Customer Card"
+{
+    layout
+    {
+        addlast(General)
+        {
+            field("Hello World"; HelloWorldTxt)
+            {
+                ApplicationArea = All;
+                Editable = false;
+            }
+        }
+    }
+
+    var
+        HelloWorldTxt: Text[30];
+
+    trigger OnAfterGetRecord()
+    begin
+        HelloWorldTxt := 'Hello World';
+    end;
+}


### PR DESCRIPTION
## Summary
- add app.json with runtime 11 for cloud
- add Hello World field pageextension for Customer Card
- configure VS Code launch settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684439ddd10c832383431c8c89d330d1